### PR TITLE
Update haproxyvm-configure.sh

### DIFF
--- a/demos/haproxy-redundant-floatingip-ubuntu/haproxyvm-configure.sh
+++ b/demos/haproxy-redundant-floatingip-ubuntu/haproxyvm-configure.sh
@@ -71,9 +71,9 @@ defaults
     mode    http
     option  httplog
     option  dontlognull
-    contimeout 5000
-    clitimeout 50000
-    srvtimeout 50000
+    timeout connect 5000ms
+    timeout client 50000ms
+    timeout server 50000ms
     errorfile 400 /etc/haproxy/errors/400.http
     errorfile 403 /etc/haproxy/errors/403.http
     errorfile 408 /etc/haproxy/errors/408.http


### PR DESCRIPTION
For the haproxy config, the existing timeout statements are no longer valid syntax and prevent the demo from running

This can be verified by viewing /var/log/haproxy.log

Fixed by modifying the three timeout statements in the HAProxy Config file to use the new syntax as per HA Proxy docs:

https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#2.1

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
